### PR TITLE
Hot-fix :  1.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 .env
-package-lock.json
-docker-compose.yaml
+*package-lock.json
+*docker-compose.yaml

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "palworld-admin-panel",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A administration panel for palworld servers. Give users the ability to see whos online and the status of the server.",
   "main": "app.js",
   "scripts": {

--- a/src/routes/manageServer.js
+++ b/src/routes/manageServer.js
@@ -130,7 +130,11 @@ router.get('/rcon/:command', async (req, res, next) => {
 
         let output = await sendSshComand(command);
         let data = organizeLogData(output);
-
+        data.arrayOfObjects.forEach(obj => {
+            if (obj.details[0] === ("/v1/api/metrics" || "/v1/api/info")){
+                delete obj;
+            }
+        });
         console.info('GET /stop: [info, metrics, output]', info, metrics, output[0, 100]);
 
         console.log(data.arrayOfObjects[0])

--- a/src/utils/fetchData.js
+++ b/src/utils/fetchData.js
@@ -38,8 +38,9 @@ const fetchData = async (config) => {
         const response = await axios(config);
         return response.data;
     } catch (error) {
-        // console.error('Error fetching data from API:', error);
-        throw error;
+        console.error('Error fetching data from API:', error);
+        // throw error;
+        return null;
     }
 };
 

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -8,7 +8,7 @@
                         <%= info.servername %>
                     </h1>
                     <div class="info-metrics">
-                        <p><small>V <%= info.version %></small></p>
+                        <p><small><%= info.version %></small></p>
                         <p><small>fps <%= metrics.serverfps %></small></p>
                         <p><small>uptime <%= metrics.uptime %></small></p>
                     </div>

--- a/src/views/modules/navigation.ejs
+++ b/src/views/modules/navigation.ejs
@@ -13,13 +13,13 @@
                 <a href="/manage/save">Save world</a>
             </li>
             <li>
-                <a href="/manage/shutdown">Shutdown server</a>
+                <a href="#/manage/shutdown">Shutdown server</a>
             </li>
             <li>
                 <a href="#sequrity-liability">Force Shutdown</a>
             </li>
             <li>
-                <a href="/manage/settings">Server settup</a>
+                <a href="#/manage/settings">Server settup</a>
             </li>
             <li>
                 <a href="/manage/rcon/readLog">

--- a/src/views/rcon.ejs
+++ b/src/views/rcon.ejs
@@ -11,22 +11,22 @@
                             </a>
                         </li>
                         <li>
-                            <a href="/manage/rcon/startServer">
+                            <a href="#/manage/rcon/startServer">
                                 star-sterver: using script.sh
                             </a>
                         </li>
                         <li>
-                            <a href="/manage/rcon/startCtl">
+                            <a href="#/manage/rcon/startCtl">
                                 start-server: using systemCtl
                             </a>
                         </li>
                         <li>
-                            <a href="/manage/rcon/stopCtl">
+                            <a href="#/manage/rcon/stopCtl">
                                 stop-server: using systemCtl
                             </a>
                         </li>
                         <li>
-                            <a href="/manage/rcon/updateServer">
+                            <a href="#/manage/rcon/updateServer">
                                 update-server
                             </a>
                         </li>
@@ -39,7 +39,7 @@
                         <%= info.servername %>
                     </h1>
                     <div class="info-metrics">
-                        <p><small>V <%= info.version %></small></p>
+                        <p><small><%= info.version %></small></p>
                         <p><small>fps <%= metrics.serverfps %></small></p>
                         <p><small>uptime <%= metrics.uptime %></small></p>
                     </div>
@@ -66,18 +66,34 @@
                 <div>
                     <h2>Palworld Log</h2>
                 </div>
-                <section class="playerContainer">
-                    <% data.arrayOfObjects.forEach(object=> { %>
-                        <div class="playerCard">
-                            <% for (const [key, value] of Object.entries(object)) {%>
-                                <p>
-                                    <%= key %>: <%= value %>
-                                </p>
-                                <% } %>
+                <% data.arrayOfObjects.forEach(object=> { %>
+                    <% if (object.playername == "REST") { %>
+                        <section class="playerContainer">
+                            <div class="playerCard">
+                                <% for (const [key, value] of Object.entries(object)) {%>
+                                    <p>
+                                        <%= key %>: <%= value %>
+                                    </p>
+                                    <% } %>
+                            </div>
+                    </section>     
+                    <% } else { %>
+                        <div>
+                            <h2>User Activity</h2>
                         </div>
-                        <% }) %>
-
-                </section>
+                        <section class="playerContainer">
+                            <div class="playerCard">
+                                <% for (const [key, value] of Object.entries(object)) {%>
+                                    <% if (value != userid) { %> 
+                                        <p>
+                                            <%= key %>: <%= value %>
+                                        </p>
+                                    <% } %>
+                                <% } %>
+                                </div>
+                            </section>
+                    <% } %>
+                <% }) %>
             </main>
             <%- include('./modules/footer.ejs') %>
     </body>

--- a/src/views/settings.ejs
+++ b/src/views/settings.ejs
@@ -8,7 +8,7 @@
                         <%= info.servername %>
                     </h1>
                     <div class="info-metrics">
-                        <p><small>V <%= info.version %></small></p>
+                        <p><small><%= info.version %></small></p>
                         <p><small>fps <%= metrics.serverfps %></small></p>
                         <p><small>uptime <%= metrics.uptime %></small></p>
                     </div>


### PR DESCRIPTION
## Hot-Fix: Rcon/commands beeing sendt by webcrawlers and shutingdown servers
- temporarly disabled links that sends potentialy destructiv commands to the server. 

## Other-fixes:
- the page for viewing server logs should  not show request sendt to  "/info" & "/metrics" endpoints as this was spamming the log page, and is a request sent on every page request.
- user events are seperated in to a seperate page block.
- fetch-request sent to the palworld api wich fails due to server beeing down, should not "crash" the page with an ecoon refused, but rather show dummy data.
- removed the  "v" before the server version in the server-info block


/hrHVN